### PR TITLE
Fixed Cloud Code Error, due to incorrect serverURL

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,7 +61,7 @@ var parseConfig = {
   appId: process.env.APP_ID,
   masterKey: process.env.MASTER_KEY,
   cloud: process.env.CLOUD_CODE_MAIN || __dirname + '/cloud/main.js',
-  serverURL: ((process.env.HTTPS) ? 'https' : 'http') + host + ':' + port + mountPath,
+  serverURL: ((process.env.HTTPS) ? 'https://' : 'http://') + host + ':' + port + mountPath,
 };
 
 // Optional Keys


### PR DESCRIPTION
Cloud Code was not working as the server url was not set properly.

I have updated the server url to the correct one (:// was missing).
